### PR TITLE
Add ItemsRef to create a reference within an items array

### DIFF
--- a/src/Swagger2/Refs/ItemsRef.php
+++ b/src/Swagger2/Refs/ItemsRef.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace WoohooLabs\SpecGenerator\Swagger2\Refs;
+
+use WoohooLabs\SpecGenerator\Swagger2\Items\ItemsInterface;
+
+/**
+ * Defining a reference for array items.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class ItemsRef extends AbstractRef implements ItemsInterface
+{
+    /**
+     * @return array
+     */
+    public function generate()
+    {
+        return ['$ref' => '#/definitions/'.$this->getRef()];
+    }
+}


### PR DESCRIPTION
Makes it possible to create a reference to an object for all items within the array:

``` yaml
    responses:
        '200':
          description: An array of objects
          schema:
            type: array
            items:
              $ref: '#/definitions/Object'
```
